### PR TITLE
fix: compressed web pages cannot be parsed normally

### DIFF
--- a/src/main/java/run/halo/editor/hyperlink/HttpClientFactory.java
+++ b/src/main/java/run/halo/editor/hyperlink/HttpClientFactory.java
@@ -47,7 +47,8 @@ public class HttpClientFactory {
 
     private static HttpClient getHttpClient() {
         return HttpClient.create()
-            .responseTimeout(Duration.ofSeconds(10));
+            .responseTimeout(Duration.ofSeconds(10))
+            .compress(true);
     }
 
     record ProxyConfig(String host, int port, List<AddressConfig> hosts) {

--- a/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkDefaultParser.java
+++ b/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkDefaultParser.java
@@ -6,6 +6,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
 import org.jsoup.select.Elements;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import run.halo.editor.hyperlink.dto.HyperLinkBaseDTO;
 
@@ -23,8 +24,11 @@ public class HyperLinkDefaultParser implements HyperLinkParser<HyperLinkBaseDTO>
         Elements meta = parse.getElementsByTag("meta");
         parserMetas(meta, hyperLinkBaseDTO);
 
-        var title = parse.getElementsByTag("title").get(0).text();
-        hyperLinkBaseDTO.setTitle(title);
+        var titles = parse.getElementsByTag("title");
+        if (!CollectionUtils.isEmpty(titles)) {
+            var title = titles.get(0).text();
+            hyperLinkBaseDTO.setTitle(title);
+        }
 
         Elements links = parse.getElementsByTag("link");
         parserLinks(links, hyperLinkBaseDTO);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

当网页使用 `gzip` 时，网页会被解析为乱码。导致解析失败。

#### How to test it?

测试请求网站 https://www.bilibili.com/video/BV1Vu4m1M7Nr/ ，查看是否会报错。

#### Which issue(s) this PR fixes:

Fixes #3 

#### Does this PR introduce a user-facing change?
```release-note
解决被压缩的网站无法解析的问题
```
