### PR TITLE
fix: solving the issue of filtered text expansion for linked cards

### DIFF
--- a/ui/src/editor/text-bubble-extension.ts
+++ b/ui/src/editor/text-bubble-extension.ts
@@ -4,6 +4,8 @@ import { markRaw } from 'vue';
 import linkViewTypes from './link-view-type';
 
 const TextBubbleExtension = Extension.create({
+  name: 'textHyperlinkCardExtension',
+
   onBeforeCreate() {
     const itemKey = 'export-text-link-view';
     this.editor.extensionManager.extensions.forEach((extension) => {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

为 text bubble Extension 增加 name

#### Does this PR introduce a user-facing change?
```release-note
解决 TextBubbleExtension 被错误过滤的问题
```
