### PR TITLE
feat: optimize the style of regular card on mobile and support for parsing bilibili mobile share links

### DIFF
--- a/packages/hyperlink-card/src/themes/regular-card.ts
+++ b/packages/hyperlink-card/src/themes/regular-card.ts
@@ -12,7 +12,11 @@ export class HyperlinkRegularCard extends LitElement {
   siteData?: SiteData;
 
   override render() {
-    return html`<div class="items-center flex flex-col sm:flex-row relative p-2 gap-3">
+    return html`<div
+      class="items-center flex ${!this.siteData?.image && this.siteData?.icon
+        ? 'flex-row'
+        : 'flex-col'} sm:flex-row relative p-2 gap-3"
+    >
       ${this.siteData?.image
         ? html`
             <div
@@ -24,19 +28,17 @@ export class HyperlinkRegularCard extends LitElement {
                 filter: `blur(64px) saturate(4) contrast(90%)`,
               })}
             ></div>
+            <div class="aspect-16/9 w-full sm:w-56 flex-none z-[1]">
+              <img
+                class="rounded-lg size-full object-cover"
+                src=${this.siteData?.image}
+                referrerpolicy="no-referrer"
+              />
+            </div>
           `
         : ''}
-      ${this.siteData?.image
-        ? html`<div class="aspect-16/9 w-full sm:w-56 flex-none z-[1]">
-            <img
-              class="rounded-lg size-full object-cover"
-              src=${this.siteData?.image}
-              referrerpolicy="no-referrer"
-            />
-          </div>`
-        : ''}
       ${!this.siteData?.image && this.siteData?.icon
-        ? html`<div class="aspect-square w-full sm:w-18 flex-none z-[1]">
+        ? html`<div class="aspect-square w-18 flex-none z-[1]">
             <img
               class="rounded-lg size-full object-cover"
               src=${this.siteData?.icon}
@@ -45,7 +47,7 @@ export class HyperlinkRegularCard extends LitElement {
           </div>`
         : ''}
 
-      <div class="flex-1 shrink space-y-1 z-[1]">
+      <div class="flex-auto shrink space-y-1 z-[1] text-ellipsis overflow-hidden w-full">
         <div>
           <span class="text-link text-xs line-clamp-1">${this.siteData?.url}</span>
         </div>

--- a/packages/hyperlink-card/src/themes/regular-card.ts
+++ b/packages/hyperlink-card/src/themes/regular-card.ts
@@ -12,8 +12,10 @@ export class HyperlinkRegularCard extends LitElement {
   siteData?: SiteData;
 
   override render() {
+    const isOnlyIcon = !this.siteData?.image && this.siteData?.icon;
+
     return html`<div
-      class="items-center flex ${!this.siteData?.image && this.siteData?.icon
+      class="items-center flex ${isOnlyIcon
         ? 'flex-row'
         : 'flex-col'} sm:flex-row relative p-2 gap-3"
     >
@@ -37,7 +39,7 @@ export class HyperlinkRegularCard extends LitElement {
             </div>
           `
         : ''}
-      ${!this.siteData?.image && this.siteData?.icon
+      ${isOnlyIcon
         ? html`<div class="aspect-square w-18 flex-none z-[1]">
             <img
               class="rounded-lg size-full object-cover"
@@ -56,7 +58,9 @@ export class HyperlinkRegularCard extends LitElement {
             ${this.siteData?.title}
           </h2>
         </div>
-        <p class="text-sm text-description line-clamp-2">${this.siteData?.description}</p>
+        <p class="text-sm text-description ${isOnlyIcon ? 'line-clamp-1' : 'line-clamp-2'}">
+          ${this.siteData?.description}
+        </p>
       </div>
     </div>`;
   }

--- a/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkBilibiliParser.java
+++ b/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkBilibiliParser.java
@@ -61,7 +61,6 @@ public class HyperLinkBilibiliParser implements HyperLinkParser<HyperLinkBaseDTO
             throw new RuntimeException("id not found");
         }
         String id = matcher.group(1);
-        System.out.println(id);
         if (id.chars().allMatch(Character::isDigit)) {
             return "aid=" + id;
         } else {

--- a/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkBilibiliParser.java
+++ b/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkBilibiliParser.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -11,6 +13,7 @@ import reactor.core.publisher.Mono;
 import run.halo.editor.hyperlink.HttpClientFactory;
 import run.halo.editor.hyperlink.dto.HyperLinkBaseDTO;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,7 +54,15 @@ public class HyperLinkBilibiliParser implements HyperLinkParser<HyperLinkBaseDTO
                     httpHeaders.set(HttpHeaders.CONTENT_TYPE, "application/json");
                 })
                 .retrieve()
-                .bodyToMono(String.class));
+                .bodyToFlux(DataBuffer.class)
+                .flatMap(dataBuffer -> {
+                    String content = dataBuffer.toString(StandardCharsets.UTF_8);
+                    DataBufferUtils.release(dataBuffer);
+                    return Mono.just(content);
+                })
+                .reduce(new StringBuilder(), StringBuilder::append)
+                .filter(stringBuilder -> !stringBuilder.isEmpty())
+                .map(StringBuilder::toString));
     }
 
     public String getQueryParam(URI linkURI) {

--- a/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkQQMusicParser.java
+++ b/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkQQMusicParser.java
@@ -73,7 +73,6 @@ public class HyperLinkQQMusicParser implements HyperLinkParser<HyperLinkBaseDTO>
             throw new RuntimeException("id not found");
         }
         String id = matcher.group(1);
-        System.out.println(id);
         if (id.chars().allMatch(Character::isDigit)) {
             return "songid=" + id;
         } else {

--- a/src/main/java/run/halo/editor/hyperlink/handler/ParserType.java
+++ b/src/main/java/run/halo/editor/hyperlink/handler/ParserType.java
@@ -10,7 +10,7 @@ public enum ParserType {
 
     DEFAULT("default", HyperLinkDefaultParser.class),
     QQMUSIC("(i.)?y.qq.com", HyperLinkQQMusicParser.class),
-    BILIBILI("[www|m].bilibili.com", HyperLinkBilibiliParser.class);
+    BILIBILI("(www|m).bilibili.com", HyperLinkBilibiliParser.class);
 
     private final String host;
     private final Class<? extends HyperLinkParser<? extends HyperLinkBaseDTO>> type;

--- a/src/main/java/run/halo/editor/hyperlink/handler/ParserType.java
+++ b/src/main/java/run/halo/editor/hyperlink/handler/ParserType.java
@@ -10,7 +10,7 @@ public enum ParserType {
 
     DEFAULT("default", HyperLinkDefaultParser.class),
     QQMUSIC("(i.)?y.qq.com", HyperLinkQQMusicParser.class),
-    BILIBILI("www.bilibili.com", HyperLinkBilibiliParser.class);
+    BILIBILI("[www|m].bilibili.com", HyperLinkBilibiliParser.class);
 
     private final String host;
     private final Class<? extends HyperLinkParser<? extends HyperLinkBaseDTO>> type;


### PR DESCRIPTION
- 当正常卡片只有 icon 参数时，手机端显示跟电脑端一样变成左右排列
- 支持解析 bilibili 手机端的分享链接

![image](https://github.com/user-attachments/assets/2e7ab550-a971-4751-a641-513bf4bbe8f6)

```release-note
优化移动端卡片样式，支持解析 bilibili 移动分享链接
```
