### PR TITLE
Update settings schema

### DIFF
--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -14,7 +14,7 @@ spec:
         - $formkit: number
           name: port
           label: HTTP 代理端口
-        - $formkit: repeater
+        - $formkit: array
           name: hosts
           label: 需要代理 host 的列表
           help: 如：github.com

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -6,7 +6,7 @@ metadata:
   name: editor-hyperlink-card
 spec:
   enabled: true
-  requires: ">=2.11.0"
+  requires: ">=2.22.0"
   author:
     name: Halo
     website: https://github.com/halo-dev


### PR DESCRIPTION
Use the new array input type introduced in Halo 2.22 to replace the repeater for better scheduling behavior.

<img width="565" height="174" alt="image" src="https://github.com/user-attachments/assets/fd4a69ca-a676-4980-82e7-b6f83a9c8e19" />

```release-note
优化插件配置表单的显示效果
```