### PR TITLE
fix: handle WebClient timeout exceptions gracefully

### DIFF
--- a/packages/hyperlink-card/src/HyperlinkCard.svelte
+++ b/packages/hyperlink-card/src/HyperlinkCard.svelte
@@ -38,7 +38,6 @@
   let siteData = $state<SiteData>();
 
   async function fetchSiteData() {
-    console.log("fetchSiteData", customTitle, customImage, customDescription);
     if (customTitle && customImage && customDescription) {
       siteData = {
         title: customTitle,
@@ -53,6 +52,10 @@
       loading = true;
 
       const response = await fetch(`/apis/api.hyperlink.halo.run/v1alpha1/link-detail?url=${href}`);
+
+      if (!response.ok) {
+        return;
+      }
 
       siteData = (await response.json()) as SiteData;
 

--- a/packages/hyperlink-card/src/HyperlinkInlineCard.svelte
+++ b/packages/hyperlink-card/src/HyperlinkInlineCard.svelte
@@ -43,6 +43,10 @@
 
       const response = await fetch(`/apis/api.hyperlink.halo.run/v1alpha1/link-detail?url=${href}`);
 
+      if (!response.ok) {
+        return;
+      }
+
       siteData = (await response.json()) as SiteData;
 
       if (customTitle) {

--- a/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkBilibiliParser.java
+++ b/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkBilibiliParser.java
@@ -3,12 +3,16 @@ package run.halo.editor.hyperlink.handler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.channel.ConnectTimeoutException;
+import io.netty.handler.timeout.ReadTimeoutException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Mono;
 import run.halo.editor.hyperlink.HttpClientFactory;
 import run.halo.editor.hyperlink.dto.HyperLinkBaseDTO;
@@ -25,6 +29,14 @@ public class HyperLinkBilibiliParser implements HyperLinkParser<HyperLinkBaseDTO
 
     public Mono<HyperLinkBaseDTO> parse(URI linkURI) {
         return getHyperLinkDetail(linkURI)
+            .onErrorMap(throwable -> {
+                if (throwable instanceof WebClientRequestException wcre
+                    && (wcre.getCause() instanceof ReadTimeoutException
+                        || wcre.getCause() instanceof ConnectTimeoutException)) {
+                    return new ServerWebInputException("Request to target service timed out.");
+                }
+                return throwable;
+            })
             .map(item -> {
                 var hyperLinkDTO = new HyperLinkBaseDTO();
                 try {

--- a/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkDefaultParser.java
+++ b/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkDefaultParser.java
@@ -1,5 +1,7 @@
 package run.halo.editor.hyperlink.handler;
 
+import io.netty.channel.ConnectTimeoutException;
+import io.netty.handler.timeout.ReadTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -18,6 +20,7 @@ import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Mono;
 import run.halo.app.infra.utils.PathUtils;
@@ -37,6 +40,14 @@ public class HyperLinkDefaultParser implements HyperLinkParser<HyperLinkBaseDTO>
     @Override
     public Mono<HyperLinkBaseDTO> parse(URI linkURI) {
         return getHyperLinkDetail(linkURI)
+                .onErrorMap(throwable -> {
+                    if (throwable instanceof WebClientRequestException wcre
+                        && (wcre.getCause() instanceof ReadTimeoutException
+                            || wcre.getCause() instanceof ConnectTimeoutException)) {
+                        return new ServerWebInputException("Request to target service timed out.");
+                    }
+                    return throwable;
+                })
                 .switchIfEmpty(
                         Mono.error(new ServerWebInputException("this website is not supported.")))
                 .map(item -> {

--- a/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkQQMusicParser.java
+++ b/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkQQMusicParser.java
@@ -3,10 +3,14 @@ package run.halo.editor.hyperlink.handler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.channel.ConnectTimeoutException;
+import io.netty.handler.timeout.ReadTimeoutException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Mono;
 import run.halo.editor.hyperlink.HttpClientFactory;
 import run.halo.editor.hyperlink.dto.HyperLinkBaseDTO;
@@ -24,6 +28,14 @@ public class HyperLinkQQMusicParser implements HyperLinkParser<HyperLinkBaseDTO>
 
     public Mono<HyperLinkBaseDTO> parse(URI linkURI) {
         return getHyperLinkDetail(linkURI)
+            .onErrorMap(throwable -> {
+                if (throwable instanceof WebClientRequestException wcre
+                    && (wcre.getCause() instanceof ReadTimeoutException
+                        || wcre.getCause() instanceof ConnectTimeoutException)) {
+                    return new ServerWebInputException("Request to target service timed out.");
+                }
+                return throwable;
+            })
             .map(item -> {
                 var hyperLinkDTO = new HyperLinkBaseDTO();
                 try {


### PR DESCRIPTION
## What this PR does

Fixes #34

When fetching link metadata via WebClient, timeout exceptions (`ReadTimeoutException`, `ConnectTimeoutException`) were previously unhandled and propagated as `500 Internal Server Error`. This is misleading because the failure is caused by the target service, not the Halo server itself. Additionally, these timeouts were logged at `ERROR` level, polluting logs with expected transient failures.

## Changes

### Backend
- Added `.onErrorMap()` in all three `HyperLinkParser` implementations (`HyperLinkDefaultParser`, `HyperLinkBilibiliParser`, `HyperLinkQQMusicParser`) to catch timeout exceptions wrapped in `WebClientRequestException`
- Map them to `ServerWebInputException("Request to target service timed out.")` which returns `400 Bad Request`
- Spring WebFlux handles `ResponseStatusException` at `WARN` level by default, avoiding `ERROR` log pollution

### Frontend
- Added `response.ok` check in both `HyperlinkCard.svelte` and `HyperlinkInlineCard.svelte`
- When the API returns a non-200 response, the component falls back to rendering the original plain link instead of attempting to parse broken error JSON
- Removed leftover `console.log` debug output

## How to test

1. Create or edit a post in Halo editor
2. Insert a hyperlink card pointing to a slow or unreachable URL
3. Verify the card renders as a plain link fallback when the target times out
4. Check server logs — timeout should appear at `WARN`, not `ERROR`

```release-note
修复 WebClient 请求超时异常被错误转换为 500 服务器错误的问题，超时现在会返回 400 并记录为 WARN 级别。同时优化了前端卡片组件，当接口请求失败时会显示原链接而不是错误信息。
```