### PR TITLE
feat: support relative URLs in link detail API

### DIFF
--- a/src/main/java/run/halo/editor/hyperlink/HyperLinkCardEndpoint.java
+++ b/src/main/java/run/halo/editor/hyperlink/HyperLinkCardEndpoint.java
@@ -2,6 +2,7 @@ package run.halo.editor.hyperlink;
 
 import static org.springdoc.core.fn.builders.apiresponse.Builder.responseBuilder;
 
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.webflux.core.fn.SpringdocRouteBuilder;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,7 @@ import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.endpoint.CustomEndpoint;
 import run.halo.app.extension.GroupVersion;
+import run.halo.app.infra.ExternalUrlSupplier;
 import run.halo.app.infra.utils.PathUtils;
 import run.halo.editor.hyperlink.dto.HyperLinkBaseDTO;
 import run.halo.editor.hyperlink.service.HyperLinkCardService;
@@ -24,6 +26,8 @@ import run.halo.editor.hyperlink.service.HyperLinkCardService;
 public class HyperLinkCardEndpoint implements CustomEndpoint {
 
     private final HyperLinkCardService hyperLinkCardService;
+
+    private final ExternalUrlSupplier externalUrlSupplier;
 
     @Override
     public RouterFunction<ServerResponse> endpoint() {
@@ -40,6 +44,16 @@ public class HyperLinkCardEndpoint implements CustomEndpoint {
 
     private Mono<ServerResponse> getHyperLinkDetail(ServerRequest request) {
         final var url = request.queryParam("url")
+            .map(rawUrl -> {
+                if (PathUtils.isAbsoluteUri(rawUrl)) {
+                    return rawUrl;
+                }
+                var externalUri = externalUrlSupplier.get();
+                if (externalUri == null) {
+                    return null;
+                }
+                return externalUri.resolve(URI.create(rawUrl)).toString();
+            })
             .filter(PathUtils::isAbsoluteUri)
             .orElseThrow(() -> new ServerWebInputException("Invalid url."));
         return hyperLinkCardService.getHyperLinkDetail(url)


### PR DESCRIPTION
## What this PR does

Fixes #23

When users insert internal links using relative paths (e.g., `/archives/hello-world`) into hyperlink cards, the backend API previously rejected them as invalid because it only accepted absolute URIs.

This PR adds support for resolving relative URLs against the site's external URL so that internal pages can also display rich card metadata.

## Changes

### Backend
- Injected `ExternalUrlSupplier` into `HyperLinkCardEndpoint`
- Added relative path detection in `getHyperLinkDetail()` before URI validation
- Relative URLs are resolved against `externalUrlSupplier.get()` using `URI.resolve()`
- Absolute URLs continue to work exactly as before
- Unresolvable input still returns the existing `400 Invalid url.` error

## Example

| Input | External URL | Resolved URL |
|-------|-------------|--------------|
| `/archives/hello-world` | `https://example.com` | `https://example.com/archives/hello-world` |
| `https://github.com/...` | — | `https://github.com/...` (unchanged) |

## How to test

1. Create or edit a post in Halo editor
2. Insert a hyperlink card with a relative path like `/archives/hello-world`
3. Verify the card renders metadata for the resolved page
4. Verify absolute URLs still work normally

```release-note
支持在超链接卡片中使用相对路径的站内链接，系统会自动将其解析为绝对 URL 后获取页面元数据。
```