### PR TITLE
fix: detect charset from Content-Type header when parsing HTML

### DIFF
--- a/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkDefaultParser.java
+++ b/src/main/java/run/halo/editor/hyperlink/handler/HyperLinkDefaultParser.java
@@ -3,8 +3,10 @@ package run.halo.editor.hyperlink.handler;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.timeout.ReadTimeoutException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
@@ -104,17 +106,27 @@ public class HyperLinkDefaultParser implements HyperLinkParser<HyperLinkBaseDTO>
                             httpHeaders.set(HttpHeaders.REFERER,
                                     linkURI.getScheme() + "://" + linkURI.getHost());
                         })
-                        .retrieve()
-                        .bodyToFlux(DataBuffer.class)
-                        .flatMap(dataBuffer -> {
-                            String content = dataBuffer.toString(StandardCharsets.UTF_8);
-                            DataBufferUtils.release(dataBuffer);
-                            return Mono.just(content);
-                        })
-                        .reduce(new StringBuilder(), StringBuilder::append)
-                        .filter(stringBuilder -> !stringBuilder.isEmpty())
-                        .map(StringBuilder::toString)
-                        .map(htmlContent -> new HyperLinkRequest.HyperLinkResponse(htmlContent, resourceUrl.get())));
+                        .exchangeToMono(clientResponse -> {
+                            Charset resolvedCharset = StandardCharsets.UTF_8;
+                            try {
+                                resolvedCharset = clientResponse.headers().contentType()
+                                        .map(MediaType::getCharset)
+                                        .orElse(StandardCharsets.UTF_8);
+                            } catch (IllegalArgumentException e) {
+                                // keep UTF-8 fallback
+                            }
+                            final Charset charset = resolvedCharset;
+                            return clientResponse.bodyToFlux(DataBuffer.class)
+                                    .flatMap(dataBuffer -> {
+                                        String content = dataBuffer.toString(charset);
+                                        DataBufferUtils.release(dataBuffer);
+                                        return Mono.just(content);
+                                    })
+                                    .reduce(new StringBuilder(), StringBuilder::append)
+                                    .filter(stringBuilder -> !stringBuilder.isEmpty())
+                                    .map(StringBuilder::toString)
+                                    .map(htmlContent -> new HyperLinkRequest.HyperLinkResponse(htmlContent, resourceUrl.get()));
+                        }));
     }
 
     private void parserLinks(Elements links, HyperLinkBaseDTO hyperLinkBaseDTO) {


### PR DESCRIPTION
## What this PR does

Fixes #20

Some websites return HTML with a non-UTF-8 charset declaration (e.g., `Content-Type: text/html; charset=GB18030`). The previous code hardcoded `StandardCharsets.UTF_8` when converting the HTTP response body from `DataBuffer` to `String`, causing garbled or missing titles and meta tags.

## Changes

- Replaced `.retrieve().bodyToFlux(DataBuffer.class)` with `.exchangeToMono(clientResponse -> ...)` in `HyperLinkDefaultParser.getHyperLinkDetail()` to access the HTTP response headers
- Extract the declared charset from the `Content-Type` header via `MediaType.getCharset()`
- Use the extracted charset when decoding `DataBuffer` chunks; fall back to UTF-8 when no charset is declared
- Catch `IllegalArgumentException` for unsupported/invalid charset values and fall back to UTF-8

## Example

| Target | Content-Type | Behavior before | Behavior after |
|--------|-------------|-----------------|----------------|
| `work.weixin.qq.com/mail/` | `text/html; charset=GB18030` | Garbled title (UTF-8 forced) | Correct Chinese title |
| `example.com/page` | `text/html; charset=utf-8` | Correct | Correct (unchanged) |
| `example.com/page` | `text/html` (no charset) | Correct | Correct (UTF-8 fallback) |

## How to test

1. Insert a hyperlink card pointing to a site that returns `charset=GB18030` (or any non-UTF-8 charset)
2. Verify the card renders the correct title and description
3. Verify absolute URLs and UTF-8 sites still work normally

```release-note
修复部分使用非 UTF-8 编码（如 GB18030）的网页无法正确获取标题和描述的问题，现在会根据 HTTP 响应头中的 Content-Type 声明自动识别编码。
```